### PR TITLE
Strictly validate the response properties.

### DIFF
--- a/lib/unexpectedExpress.js
+++ b/lib/unexpectedExpress.js
@@ -9,7 +9,16 @@ var http = require('http'),
     _ = require('underscore'),
     FormData = require('form-data'),
     messy = require('messy'),
-    metadataPropertyNames = ['strictAsync', 'errorPassedToNext', 'isDestroyed', 'nextCalled', 'locals', 'url', 'requestDestroyed'];
+    metadataPropertyNames = ['strictAsync', 'errorPassedToNext', 'isDestroyed', 'nextCalled', 'locals', 'url', 'requestDestroyed'],
+    responsePropertyNames = messy.HttpResponse.propertyNames.concat(metadataPropertyNames);
+
+function hasKeys(x) {
+    return Object.keys(x).length > 0;
+}
+
+function validateResponseProperties(x) {
+    return _.intersection(Object.keys(x), responsePropertyNames).length > 0;
+}
 
 module.exports = {
     name: 'unexpected-express',
@@ -134,16 +143,23 @@ module.exports = {
                 delete requestProperties.query;
             }
 
+            var responseProperties = value.response;
+            delete value.response;
             var expectedResponseProperties;
 
-            if (typeof value.response === 'number') {
-                expectedResponseProperties = {statusCode: value.response};
-            } else if (typeof value.response === 'string' || Buffer.isBuffer(value.response)) {
-                expectedResponseProperties = {body: value.response};
+            if (typeof responseProperties === 'number') {
+                expectedResponseProperties = {statusCode: responseProperties};
+            } else if (typeof responseProperties === 'string' || Buffer.isBuffer(responseProperties)) {
+                expectedResponseProperties = {body: responseProperties};
+            } else if (Array.isArray(responseProperties)) {
+                throw new Error('unexpected-express: Response object must be a number, string, buffer or object.');
             } else {
-                expectedResponseProperties = _.extend({}, value.response);
+                if (responseProperties && hasKeys(responseProperties) && !validateResponseProperties(responseProperties)) {
+                    throw new Error('unexpected-express: Response object specification incomplete.');
+                }
+
+                expectedResponseProperties = _.extend({}, responseProperties);
             }
-            delete value.response;
 
             var expectedMetadata = _.extend(
                     {},
@@ -153,7 +169,7 @@ module.exports = {
             expectedResponseProperties = _.omit(expectedResponseProperties, metadataPropertyNames);
 
             var missingResponseProperties = Object.keys(expectedResponseProperties).filter(function (key) {
-                return messy.HttpResponse.propertyNames.indexOf(key) === -1 && metadataPropertyNames.indexOf(key) === -1 && key !== 'url' && key !== 'locals';
+                return responsePropertyNames.indexOf(key) === -1;
             });
             if (missingResponseProperties.length > 0) {
                 throw new Error('Property "' + missingResponseProperties[0] + '" does not exist on the response object.');

--- a/test/unexpectedExpress.js
+++ b/test/unexpectedExpress.js
@@ -803,11 +803,34 @@ describe('unexpectedExpress', function () {
         );
     });
 
+    it('should throw an error when a response object is an array', function () {
+        expect(function () {
+            expect(function (req, res, next) { next(); }, 'to yield exchange', {
+                request: '/foo',
+                response: []
+            });
+        }, 'to throw', /unexpected-express: Response object must be a number, string, buffer or object/);
+    });
+
+    it('should throw an error when a response object is specified but incomplete', function () {
+        expect(function () {
+            expect(function (req, res, next) { next(); }, 'to yield exchange', {
+                request: '/foo',
+                response: {
+                    foo: 'quux'
+                }
+            });
+        }, 'to throw', /unexpected-express: Response object specification incomplete/);
+    });
+
     it('should throw an error when a nonexistent property is added on the response object', function () {
         expect(function () {
             expect(function (req, res, next) { next(); }, 'to yield exchange satisfying', {
                 request: '/foo',
                 response: {
+                    body: {
+                        baz: 'xuuq'
+                    },
                     fooBar: 'quux'
                 }
             });
@@ -823,6 +846,21 @@ describe('unexpectedExpress', function () {
                 fooBar: 'quuuux'
             }
         });
+    });
+
+    it('should assert the presence of any additional properties set on the response object', function () {
+        expect(function () {
+            expect(function (req, res, next) {
+                res.fooBar = 'quux';
+                next();
+            }, 'to yield exchange satisfying', {
+                request: '/foo',
+                response: {
+                    statusCode: 200,
+                    fooBar: 'quux'
+                }
+            });
+        }, 'to throw', /Property "fooBar" does not exist on the response object/);
     });
 
     it('should allow using locals on the response object', function () {


### PR DESCRIPTION
This fixes the following two corner cases of response property values:
* supplying an array
* supplying an an object with arbitrary properties

The latter is a tricky case, because unlike requests specifying an object
here does not use that as the body of the response. Instead, arbitrarily
named properties are attached to the response object. This asymmetry with
the request spec is unfortunate because with a cursory glance it can be
hard to tell a body assertion is not being made given the precedent.

This is addressed here by forcing any *non-empty* request spec to contain
at minimum a single additional property of the request and it is intended
an error in this case will better guide the user to identify the problem.