### PR TITLE
Add ability to upload files in formData by supplying a file system readStream

### DIFF
--- a/lib/unexpectedExpress.js
+++ b/lib/unexpectedExpress.js
@@ -6,6 +6,7 @@ if (typeof setImmediate === 'undefined') {
 
 var http = require('http'),
     stream = require('stream'),
+    isStream = require('is-stream'),
     _ = require('underscore'),
     FormData = require('form-data'),
     messy = require('messy'),
@@ -108,8 +109,11 @@ module.exports = {
                 requestBody = new FormData();
                 Object.keys(requestProperties.formData).forEach(function (name) {
                     var value = requestProperties.formData[name],
-                        options;
-                    if (typeof value === 'object' && !Buffer.isBuffer(value)) {
+                        options = {};
+
+                    if (isStream.readable(value) && value.path) {
+                        options.filename = value.path;
+                    } else if (typeof value === 'object' && !Buffer.isBuffer(value)) {
                         options = _.extend({}, value);
                         value = options.value;
                         delete options.value;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "bufferedstream": "1.6.0",
     "form-data": "0.2.0",
+    "is-stream": "^1.1.0",
     "messy": "^6.6.1",
     "underscore": "1.6.0",
     "unexpected-messy": "^6.0.0"


### PR DESCRIPTION
Superagent and supertest allows uploading files as part of a multipart request by defining an `fs.readStream` instance:

```js
request
  .post('/upload')
  .attach('avatar', 'path/to/tobi.png', 'user.png')
  .attach('image', 'path/to/loki.png')
  .attach('file', 'path/to/jane.png')
  .end(callback);
```

https://visionmedia.github.io/superagent/#multipart-requests

It would be nice to be able to do the same in unexpected-express.

This PR adds the ability to do the same, alongside with the previous method of supplying an object with a buffer, content type and filename. These two ways of attaching are now equivalent:

```js
formData: {
  fromReadStream: fs.createReadStream('image.png'),
  fromBufferObject: {
    value: fs.readFileSync('image.png'),
    contentType: 'image/png',
    filename: 'image.png'
  }
}
```