### PR TITLE
Add strict check of request property names

### DIFF
--- a/lib/unexpectedExpress.js
+++ b/lib/unexpectedExpress.js
@@ -12,7 +12,8 @@ var http = require('http'),
     qs = require('qs'),
     messy = require('messy'),
     metadataPropertyNames = ['strictAsync', 'errorPassedToNext', 'isDestroyed', 'nextCalled', 'locals', 'url', 'requestDestroyed'],
-    responsePropertyNames = messy.HttpResponse.propertyNames.concat(metadataPropertyNames);
+    responsePropertyNames = messy.HttpResponse.propertyNames.concat(metadataPropertyNames),
+    requestPropertyNames = messy.HttpRequest.propertyNames.concat(['ip', 'remoteAddress', 'res', 'formData', 'form', 'https', 'httpVersion']);
 
 function hasKeys(x) {
     return Object.keys(x).length > 0;
@@ -77,6 +78,13 @@ module.exports = {
                     unchunkedBody: requestProperties.unchunkedBody,
                     rawBody: requestProperties.rawBody
                 });
+
+            var missingRequestProperties = Object.keys(requestProperties).filter(function (key) {
+                return requestPropertyNames.indexOf(key) === -1;
+            });
+            if (missingRequestProperties.length > 0) {
+                throw new Error('Property "' + missingRequestProperties[0] + '" does not exist on the request object.');
+            }
 
             function updateHttpRequestBody(requestBody) {
                 if (Buffer.isBuffer(requestBody)) {

--- a/test/unexpectedExpress.js
+++ b/test/unexpectedExpress.js
@@ -925,6 +925,20 @@ describe('unexpectedExpress', function () {
         }, 'to throw', /unexpected-express: Response object specification incomplete/);
     });
 
+    it('should fail if an unsupported request option is specified', function () {
+        return expect(function () {
+            return expect(express().use(function (req, res, next) {
+                res.status(200).end();
+            }), 'to yield exchange satisfying', {
+                request: {
+                    url: '/foo',
+                    fooBar: 'quux'
+                },
+                response: 200
+            });
+        }, 'to throw', /Property "fooBar" does not exist on the request object/);
+    });
+
     it('should throw an error when a nonexistent property is added on the response object', function () {
         expect(function () {
             expect(function (req, res, next) { next(); }, 'to yield exchange satisfying', {
@@ -937,17 +951,6 @@ describe('unexpectedExpress', function () {
                 }
             });
         }, 'to throw', /Property "fooBar" does not exist on the response object/);
-    });
-
-    it('should extend the req object with any additional properties set on the request object', function () {
-        return expect(function (req, res, next) {
-            expect(req, 'to have property', 'fooBar', 'quuuux');
-            next();
-        }, 'to yield exchange satisfying', {
-            request: {
-                fooBar: 'quuuux'
-            }
-        });
     });
 
     it('should assert the presence of any additional properties set on the response object', function () {


### PR DESCRIPTION
Does away with the feature that adds any unrecognized property to `req`, so this is semver-major. I forgot what the use case for that is -- anyone?