### PR TITLE
Fix typo on the front page of the documentation site

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -180,13 +180,13 @@ There are three commonly used way to POST content to a backend: JSON POST-reques
 
 ### JSON
 
-To test JSON POST-requests you can use the `request` object's `body` property:
+To test JSON POST-requests you can use the `request` object's `data` property:
 
 ```js#async:true
 return expect(express().use(myMiddleware), 'to yield exchange', {
   request: {
     url: 'POST /api/',
-    body: {
+    data: {
       title: 'Hello World',
     },
   },


### PR DESCRIPTION
- For JSON POST-requests, the correct property name for the `request` object is `data`, not `body`.

- Fixes https://github.com/unexpectedjs/unexpected-express/issues/144