### PR TITLE
Fix problem with missing hexadecimal matching for multipart form-data boundary matchers

### DIFF
--- a/test/unexpectedExpress.js
+++ b/test/unexpectedExpress.js
@@ -821,7 +821,7 @@ describe('unexpectedExpress', () => {
   it('should support sending a multipart/form-data request via formData: {...}', () =>
     expect(
       express().use((req, res, next) => {
-        const contentTypeRegExp = /^multipart\/form-data; boundary=([-\d]+)$/;
+        const contentTypeRegExp = /^multipart\/form-data; boundary=([-\da-z]+)$/;
 
         const contentType = req.header('Content-Type');
 
@@ -885,7 +885,7 @@ describe('unexpectedExpress', () => {
 
     return expect(
       express().use((req, res, next) => {
-        const contentTypeRegExp = /^multipart\/form-data; boundary=([-\d]+)$/;
+        const contentTypeRegExp = /^multipart\/form-data; boundary=([-\da-z]+)$/;
 
         const contentType = req.header('Content-Type');
 
@@ -954,7 +954,7 @@ describe('unexpectedExpress', () => {
       express()
         .use(bodyParser.urlencoded({ extended: true }))
         .use((req, res, next) => {
-          const contentTypeRegExp = /^multipart\/form-data; boundary=([-\d]+)$/;
+          const contentTypeRegExp = /^multipart\/form-data; boundary=([-\da-z]+)$/;
 
           const contentType = req.header('Content-Type');
 


### PR DESCRIPTION
Test suite failed out of the box on a clean checkout and `npm i && npm t` with:

```
  1) unexpectedExpress
       should support sending a multipart/form-data request via formData: {...}:
     UnexpectedError:
expected 'multipart/form-data; boundary=--------------------------ae8f5252c8270531b269d3b7'
to match /^multipart\/form-data; boundary=([-\d]+)$/
```

running on node 23.11.0